### PR TITLE
Don't volume mount package.json

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,7 +15,6 @@ services:
     volumes:
       - ./frontend/bidsoup/src:/usr/app/src/
       - ./frontend/bidsoup/public:/usr/app/public/
-      - ./frontend/bidsoup/package.json/:/usr/app/package.json
     ports:
       - 3000:3000
     environment:


### PR DESCRIPTION
Having package.json volume mounted doesn't allow it to be
updated since npm doesn't seem to like it. If an update is
needed for a live container during dev, use docker exec or
docker cp.