### PR TITLE
Only drop bid tables with updatedb

### DIFF
--- a/backend/bidsoup/bids/management/commands/updatedb.py
+++ b/backend/bidsoup/bids/management/commands/updatedb.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
                 with psycopg2.connect(dbname='postgres', user='postgres', password=passwd, host='db') as conn:
                     tables = []
                     with conn.cursor() as curs:
-                        curs.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+                        curs.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE 'bids%'")
                         for t in curs.fetchall():
                             tables.append(t[0])
 
@@ -34,7 +34,7 @@ class Command(BaseCommand):
                             curs.execute(command)
 
                 conn.close()
-                self.stdout.write('All tables dropped. Now performing all migrations.')
+                self.stdout.write('All bid tables dropped. Now performing all migrations.')
             else:
                 self.stdout.write('Performing migrations only.')
 


### PR DESCRIPTION
Calling updatedb --reset would drop all tables and re-apply
migraions. Since it is unlikely to corrupt non project tables or
data, the command is updated to only drop the bids prefixed tables.