### PR TITLE
Fix URLs returned by backend

### DIFF
--- a/backend/bidsoup/bidsoup/settings.py
+++ b/backend/bidsoup/bidsoup/settings.py
@@ -32,6 +32,9 @@ else:
     # Todo: Restore this to false
     DEBUG = True
 
+# When debugging, the frontened is proxied to backend so use the forwarded host.
+USE_X_FORWARDED_HOST = DEBUG
+
 ALLOWED_HOSTS = ['need_domain.com']
 if DEBUG:
     ALLOWED_HOSTS += ['*']


### PR DESCRIPTION
When the frontend is proxied to the backend, django rest framework
was returning it's URL instead of what the frontend needs to use
to prevent CORS. This causes the forwarded host to be used when in
debug mode.