### PR TITLE
Use url instead of id for resources

### DIFF
--- a/backend/bidsoup/bids/serializers.py
+++ b/backend/bidsoup/bids/serializers.py
@@ -6,36 +6,31 @@ from rest_framework_recursive.fields import RecursiveField
 class BidSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Bid
-        fields = ('id', 'name', 'description', 'bid_date', 'customer', 'tax_percent')
+        fields = ('url', 'name', 'description', 'bid_date', 'customer', 'tax_percent')
 
 class BidItemSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = BidItem
-        fields = ('id', 'bid', 'unit_type', 'price', 'description', 'notes', 'category', 'markup_percent', 'quantity', 'parent')
+        fields = ('url', 'bid', 'unit_type', 'price', 'description', 'notes', 'category', 'markup_percent', 'quantity', 'parent')
 
 class BidTaskSerializer(serializers.HyperlinkedModelSerializer):
     children = serializers.ListField(source='children.all', read_only=True, child=RecursiveField())
 
     class Meta:
         model = BidTask
-        fields = ('id', 'parent', 'children', 'bid', 'title', 'description')
+        fields = ('url', 'parent', 'children', 'bid', 'title', 'description')
 
 class CategorySerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Category
-        fields = ('id', 'bid', 'name', 'description', 'markup_percent', 'color')
+        fields = ('url', 'bid', 'name', 'description', 'markup_percent', 'color')
 
 class CustomerSerializer(serializers.HyperlinkedModelSerializer):
-    class BidSer(serializers.HyperlinkedModelSerializer):
-        class Meta:
-            model = Bid
-            fields = ('id', 'name', 'bid_date')
-
     class Meta:
         model = Customer
-        fields = ('id', 'name', 'email', 'phone')
+        fields = ('url', 'name', 'email', 'phone')
 
 class UnitTypeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = UnitType
-        fields = ('id', 'name', 'description', 'unit', 'unit_price')
+        fields = ('url', 'name', 'description', 'unit', 'unit_price')

--- a/backend/bidsoup/bids/urls.py
+++ b/backend/bidsoup/bids/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 router = routers.DefaultRouter()
 router.register(r'bids', views.BidViewSet)
-router.register(r'biditems', views.BidItemViewSet, base_name='biditems')
+router.register(r'biditems', views.BidItemViewSet, base_name='biditem')
 router.register(r'bidtasks', views.BidTaskViewSet, base_name='bidtask')
 router.register(r'customers', views.CustomerViewSet)
 router.register(r'categories', views.CategoryViewSet, base_name='category')


### PR DESCRIPTION
Since URLs for REST are a unique way to describe a resource
and are more informative than ids, this change exchanges the
id field from resource serializers for a more descriptive url
field. This also more closely matches what is returned for
related fields.