### PR TITLE
Fix updatedb command rolling back migrations

### DIFF
--- a/backend/bidsoup/bids/management/commands/updatedb.py
+++ b/backend/bidsoup/bids/management/commands/updatedb.py
@@ -35,6 +35,7 @@ class Command(BaseCommand):
 
                 conn.close()
                 self.stdout.write('All bid tables dropped. Now performing all migrations.')
+                call_command('migrate', 'bids', 'zero', fake=True)
             else:
                 self.stdout.write('Performing migrations only.')
 


### PR DESCRIPTION
When the updatedb command was called with the --reset flag the
tables were dropped but Django maintained that the migrations had
been applied. This resulted in the 'migrate' command starting from the
incorrect place. Fix by reverting Django's awareness of bid migrations
back to zero.