### PR TITLE
Fix bug in array2Hash function

### DIFF
--- a/frontend/bidsoup/src/app/utils/sorting.ts
+++ b/frontend/bidsoup/src/app/utils/sorting.ts
@@ -2,8 +2,8 @@ export const array2HashByKey = <T extends Record<K, string>, K extends keyof T>(
   arr.reduce(
     (hash, el) => (
       el[key] in hash
-        ? Object.assign(hash, {[el[key]]: [el, ...hash[el[key]]]})
-        : Object.assign(hash, {[el[key]]: el})
+        ? Object.assign(hash, {[el[key]]: [...hash[el[key]], el]})
+        : Object.assign(hash, {[el[key]]: [el]})
     ),
     {} as {[k in T[K]]: T[]}
   ));


### PR DESCRIPTION
Each element of the hash returned by array2hash should be an array, but
the current implementation did not always do this. array2hash would
sometimes return an object as the value of an element if only a single
object from the original array matched the value for the specified key.