### PR TITLE
Add links to related resources bid detail view

### DIFF
--- a/backend/bidsoup/bids/serializers.py
+++ b/backend/bidsoup/bids/serializers.py
@@ -1,12 +1,39 @@
 from .models import Bid, BidTask, BidItem, Category, Customer, UnitType
 from rest_framework import serializers
 from rest_framework_recursive.fields import RecursiveField
+from rest_framework_nested.relations import NestedHyperlinkedRelatedField
 
 
 class BidSerializer(serializers.HyperlinkedModelSerializer):
+    def __init__(self, *args, **kwargs):
+        # Don't pass custom kwargs to super
+        fields = kwargs.pop('fields', None)
+        exclude_fields = kwargs.pop('exclude_fields', None)
+
+        assert not (fields and exclude_fields), 'Cannot provide fields and exclude_fields'
+
+        super().__init__(*args, **kwargs)
+
+        if fields is not None:
+            # Drop all fields not specified
+            allowed = set(fields)
+            existing = set(self.fields)
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)
+        elif exclude_fields is not None:
+            # Remove all fields listed
+            for field_name in exclude_fields:
+                self.fields.pop(field_name)
+
+
+    biditems = serializers.HyperlinkedIdentityField(view_name='bid-biditem-list', lookup_url_kwarg='bid_pk', many=False)
+    bidtasks = serializers.HyperlinkedIdentityField(view_name='bid-bidtask-list', lookup_url_kwarg='bid_pk', many=False)
+    categories = serializers.HyperlinkedIdentityField(view_name='bid-category-list', lookup_url_kwarg='bid_pk', many=False)
+
     class Meta:
         model = Bid
-        fields = ('url', 'name', 'description', 'bid_date', 'customer', 'tax_percent')
+        fields = ('url', 'name', 'description', 'bid_date', 'customer', 'tax_percent', 'biditems', 'bidtasks', 'categories')
+
 
 class BidItemSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/backend/bidsoup/bids/views.py
+++ b/backend/bidsoup/bids/views.py
@@ -35,6 +35,13 @@ class BidViewSet(viewsets.ModelViewSet):
     queryset = Bid.objects.all().order_by('-created_on')
     serializer_class = BidSerializer
 
+    def list(self, request):
+        # Don't provide the subresource links in list view
+        queryset = self.get_queryset()
+        to_exclude = ('biditems', 'bidtasks', 'categories')
+        serializer = BidSerializer(queryset, exclude_fields=to_exclude, many=True, context={'request': request})
+        return Response(serializer.data)
+
 
 class BidItemViewSet(TrapDjangoValidationErrorMixin, viewsets.ModelViewSet):
     serializer_class = BidItemSerializer


### PR DESCRIPTION
When requesting a specific bid resource, serialize the links to the
bidtask, biditem and category resources for that bid.