### PR TITLE
Fix missing form from DRF

### DIFF
--- a/backend/bidsoup/bidsoup/settings.py
+++ b/backend/bidsoup/bidsoup/settings.py
@@ -106,6 +106,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PARSER_CLASSES': (
         'djangorestframework_camel_case.parser.CamelCaseJSONParser',
+        'rest_framework.parsers.FormParser',
     ),
 }
 


### PR DESCRIPTION
Fix the missing HTML form tab from the django rest framework browsable
API.