### PR TITLE
Add link to account from bid

### DIFF
--- a/backend/bidsoup/bids/serializers.py
+++ b/backend/bidsoup/bids/serializers.py
@@ -42,14 +42,14 @@ class BidSerializer(serializers.HyperlinkedModelSerializer):
             for field_name in exclude_fields:
                 self.fields.pop(field_name)
 
-
+    account = serializers.HyperlinkedRelatedField(view_name='account-detail', lookup_field='slug', read_only=True)
     biditems = serializers.HyperlinkedIdentityField(view_name='bid-biditem-list', lookup_url_kwarg='bid_pk', many=False)
     bidtasks = serializers.HyperlinkedIdentityField(view_name='bid-bidtask-list', lookup_url_kwarg='bid_pk', many=False)
     categories = serializers.HyperlinkedIdentityField(view_name='bid-category-list', lookup_url_kwarg='bid_pk', many=False)
 
     class Meta:
         model = Bid
-        fields = ('url', 'name', 'description', 'bid_date', 'customer', 'tax_percent',
+        fields = ('url', 'name', 'description', 'bid_date', 'account', 'customer', 'tax_percent',
             'biditems', 'bidtasks', 'categories', 'key')
         extra_kwargs = {
             'key': {'read_only': 'true'}

--- a/backend/bidsoup/bidsoup/settings.py
+++ b/backend/bidsoup/bidsoup/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_extensions',
     'rest_framework',
 ]
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 uWSGI==2.0.15
 Django==2.0.1
+django-extensions==2.1.3
 djangorestframework==3.7.7
 djangorestframework-camel-case==0.2.0
 djangorestframework-jwt==1.11.0


### PR DESCRIPTION
This adds a link to the account url from the bid list and bid detail.
Also, django-extensions is added as a dependency for easier debugging
and hepful django administration features.