### PR TITLE
Remove usage of Link component

### DIFF
--- a/frontend/bidsoup/src/app/dashboard/components/BidCard.tsx
+++ b/frontend/bidsoup/src/app/dashboard/components/BidCard.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styled from 'styled-components';
 import Card from '@app/components/Card';
 import { theme } from '@utils/color';
-import Link from '@app/components/Link';
 
 const CardContainer = styled(Card)`
   margin: 1em;
@@ -28,17 +27,17 @@ interface Props {
   name: string;
   customer: string | null;
   url: string;
-  route: string;
+  onSelect: () => void;
 }
 
 const BidCard = (props: Props) => {
   return(
-    <Link to={props.route}>
-      <CardContainer >
-        <Title>{props.name}</Title>
-        <Truncate>{props.customer}</Truncate>
-      </CardContainer>
-    </Link>
+    <CardContainer
+      onClick={props.onSelect}
+    >
+      <Title>{props.name}</Title>
+      <Truncate>{props.customer}</Truncate>
+    </CardContainer>
   );
 };
 

--- a/frontend/bidsoup/src/app/dashboard/components/BidSelector.tsx
+++ b/frontend/bidsoup/src/app/dashboard/components/BidSelector.tsx
@@ -20,9 +20,10 @@ const Container = styled.div`
 interface Props {
   bids: Bid[];
   account: string | null;
+  onSelect: (bidId: number) => void;
 }
 
-const generateBidCards = ({bids, account}: Props) => {
+const generateBidCards = ({bids, account, onSelect}: Props) => {
   return bids.map(bid => (
     <BidCard
       key={bid.url}
@@ -30,7 +31,7 @@ const generateBidCards = ({bids, account}: Props) => {
       customer={bid.customer}
       url={bid.url}
       bidNumber={bid.key}
-      route={`/${account}/bids/${bid.key}`}
+      onSelect={() => onSelect(bid.key)}
     />
   ));
 };

--- a/frontend/bidsoup/src/app/dashboard/components/Dashboard.tsx
+++ b/frontend/bidsoup/src/app/dashboard/components/Dashboard.tsx
@@ -40,6 +40,7 @@ interface ItemWithTotal extends BidItem {
 }
 
 interface Props {
+  account: string;
   bid: number | null;
   bids: Bid[];
   units: Unit[];
@@ -49,6 +50,9 @@ interface Props {
     [s: string]: CategoryWithItems;
   };
   loading: boolean;
+  history: {
+    push: (url: string) => void;
+  };
   loadPage: () => Promise<Actions>;
   selectBid: () => Promise<Actions>;
   createUnitType: (u: Partial<Unit>) => Promise<UnitActions>;
@@ -95,7 +99,9 @@ class Dashboard extends React.Component<Props> {
   render() {
     return (
       <Container>
-        <BidSelectorContainer/>
+        <BidSelectorContainer
+          onSelect={(bid: number) => this.props.history.push(`/${this.props.account}/bids/${bid}`)}
+        />
         <OverviewContainer>
           {this.generateBody()}
         </OverviewContainer>

--- a/frontend/bidsoup/src/app/dashboard/containers/BidSelectorContainer.ts
+++ b/frontend/bidsoup/src/app/dashboard/containers/BidSelectorContainer.ts
@@ -2,6 +2,10 @@ import { connect } from 'react-redux';
 import BidSelector from '@dashboard/components/BidSelector';
 import { AppState, Bid, Customer } from '@app/types/types';
 
+interface OwnProps {
+  onSelect: (bidId: number) => void;
+}
+
 const bidsWithCustomer = (bids: Bid[], customers: Customer[]) => (
   bids.map(bid => {
     let customer = customers.find(cust => cust.url === bid.customer);
@@ -12,9 +16,10 @@ const bidsWithCustomer = (bids: Bid[], customers: Customer[]) => (
   })
 );
 
-const mapStateToProps = ({bids, customers, account}: AppState) => ({
+const mapStateToProps = ({bids, customers, account}: AppState, ownProps: OwnProps) => ({
   bids: bidsWithCustomer(bids.list, customers.list),
-  account
+  account,
+  onSelect: ownProps.onSelect
 });
 
 const BidSelectorContainer = connect(mapStateToProps)(BidSelector);

--- a/frontend/bidsoup/src/app/dashboard/containers/DashboardContainer.js
+++ b/frontend/bidsoup/src/app/dashboard/containers/DashboardContainer.js
@@ -47,8 +47,9 @@ const unitsArray = units => (
 );
 
 const mapStateToProps = (state, ownProps) => ({
+  account: state.account,
   bids: state.bids.list,
-  selectedBid: bidWithCustomer(state.bids.selectedBid, state.customers.list),
+  bid: ownProps.match.params.bid,
   categoriesWithItems: itemsByCategory(
     state.bidData.items.list,
     state.bidData.categories.list,
@@ -56,7 +57,7 @@ const mapStateToProps = (state, ownProps) => ({
     state.bids.selectedBid.taxPercent
   ),
   customers: state.customers.list,
-  bid: ownProps.match.params.bid,
+  selectedBid: bidWithCustomer(state.bids.selectedBid, state.customers.list),
   units: unitsArray(state.bidData.units.units)
 });
 


### PR DESCRIPTION
Instead of using the `Link` component from react-router which is a wrapper to the anchor tag, just access the `push` function.