### PR TITLE
Cleanup TSLint warnings

### DIFF
--- a/frontend/bidsoup/src/app/actions/unitOptionsActions.ts
+++ b/frontend/bidsoup/src/app/actions/unitOptionsActions.ts
@@ -34,7 +34,7 @@ export const fetchUnitOptions = ():
       dispatch(UnitOptionsActions.requestUnits());
       return Http2.Defaults.options(e.unittypes, unitOptions)
       .map<UnitOptionsActions>(units => {
-        return dispatch(UnitOptionsActions.receiveUnits(units['actions']['POST']['unit']['choices']));
+        return dispatch(UnitOptionsActions.receiveUnits(units.actions['POST']['unit']['choices']));
       })
       .getOrElseL(err => dispatch(UnitOptionsActions.receiveUnitsFailure(err))).run();
     }).getOrElseL(() => Promise.reject())

--- a/frontend/bidsoup/src/app/components/buttons/TextButton.tsx
+++ b/frontend/bidsoup/src/app/components/buttons/TextButton.tsx
@@ -24,7 +24,7 @@ const Button = styled.button<ButtonProps>`
   border-radius: .5em;
   padding: .5em 1em;
   font-size: 1em;
-  pointer-events: ${props => props.active ? 'auto': 'none'};
+  pointer-events: ${props => props.active ? 'auto' : 'none'};
   &:hover {
     background-color: ${props => props.buttonColor.toRgba(.1)};
   }

--- a/frontend/bidsoup/src/app/dashboard/components/BidOverview.tsx
+++ b/frontend/bidsoup/src/app/dashboard/components/BidOverview.tsx
@@ -62,13 +62,16 @@ const deleteBidModal = (props: Props) => (
   <DangerActionModal
     showIf="deleteBidModal"
     title="Delete current bid?"
-    body={`This action cannot be undone. "${props.bid.name}", and the related tasks, items, units, and categories will be deleted.`}
+    body={`
+      This action cannot be undone. "${props.bid.name}", and the related tasks, items, units, and categories will be
+      deleted.
+    `}
     confirmButtonLabel="Yes, Delete"
     onCloseCancel={false}
     cancelAction={() => props.hideModal('deleteBidModal')}
     confirmAction={() => props.deleteBid(props.bid.url).then(() => props.hideModal('deleteBidModal'))}
   />
-)
+);
 
 const BidOverview = (props: Props) => {
 

--- a/frontend/bidsoup/src/app/dashboard/components/EditUnitForm.tsx
+++ b/frontend/bidsoup/src/app/dashboard/components/EditUnitForm.tsx
@@ -88,14 +88,6 @@ const DeleteWrapper = styled.span`
 
 export default class EditUnitForm extends React.Component<Props, State> {
 
-  private validation = {
-    category: textValidation(),
-    description: textValidation({isRequired: false, maxLength: 100}),
-    name: textValidation({isRequired: true}),
-    unit: textValidation({isRequired: true}),
-    unitPrice: numberValidation({isRequired: true}),
-  };
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -216,4 +208,12 @@ export default class EditUnitForm extends React.Component<Props, State> {
       </Wrapper>
     );
   }
+
+  private validation = {
+    category: textValidation(),
+    description: textValidation({isRequired: false, maxLength: 100}),
+    name: textValidation({isRequired: true}),
+    unit: textValidation({isRequired: true}),
+    unitPrice: numberValidation({isRequired: true}),
+  };
 }

--- a/frontend/bidsoup/src/app/dashboard/containers/BidOverviewContainer.ts
+++ b/frontend/bidsoup/src/app/dashboard/containers/BidOverviewContainer.ts
@@ -67,13 +67,23 @@ const bidWithCustomer = (bid: Bid, customers: Customer[]): Bid => ({
 const mapStateToProps = (state: AppState, ownProps: RouteComponentProps<{bid: string}>): StateProps => ({
   selectedBidId: Number(ownProps.match.params.bid),
   categories: state.bidData.categories.list,
-  bid: isDefined(state.bids.selectedBid.customer) ? bidWithCustomer(state.bids.selectedBid, state.customers.list) : state.bids.selectedBid,
+  bid: isDefined(state.bids.selectedBid.customer)
+    ? bidWithCustomer(state.bids.selectedBid, state.customers.list)
+    : state.bids.selectedBid,
   units: unitsArray(state.bidData.units.units),
-  bidTotal: calculateBidTotal(state.bidData.units.units, state.bidData.categories.list, state.bidData.items.list, state.bids.selectedBid),
+  bidTotal: calculateBidTotal(
+    state.bidData.units.units,
+    state.bidData.categories.list,
+    state.bidData.items.list,
+    state.bids.selectedBid
+  ),
   unitOptions: state.unitOptions.unitOptions
 });
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<AppState, never, Actions | uiActions>, ownProps: RouteComponentProps<{bid: string}>): DispatchProps => ({
+const mapDispatchToProps = (
+  dispatch: ThunkDispatch<AppState, never, Actions | uiActions>,
+  ownProps: RouteComponentProps<{bid: string}>
+): DispatchProps => ({
   createUnitType: (unit: Partial<Unit>) => dispatch(createUnitType(unit)),
   loadPage: () => (
     dispatch(fetchBidListByAccount())

--- a/frontend/bidsoup/src/app/dashboard/containers/EditUnitFormContainer.ts
+++ b/frontend/bidsoup/src/app/dashboard/containers/EditUnitFormContainer.ts
@@ -29,7 +29,10 @@ const mapStateToProps = (state: AppState, ownProps: OwnProps): OwnProps & StateP
   unitOptions: state.unitOptions.unitOptions
 });
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<AppState, never, Actions | UnitOptionsActions>, ownProps: OwnProps): DispatchProps => ({
+const mapDispatchToProps = (
+  dispatch: ThunkDispatch<AppState, never, Actions | UnitOptionsActions>,
+  ownProps: OwnProps
+): DispatchProps => ({
   updateUnit: (unit: Unit) => dispatch(updateUnitType(unit)),
   deleteUnit: () => dispatch(deleteUnitType(ownProps.unit.url)),
   fetchUnitOptions: () => dispatch(fetchUnitOptions())

--- a/frontend/bidsoup/src/app/reducers/unitOptionsReducer.ts
+++ b/frontend/bidsoup/src/app/reducers/unitOptionsReducer.ts
@@ -18,7 +18,10 @@ const defaultState: UnitOptionsState = {
   unitOptions: []
 };
 
-const unitOptionsReducer: Reducer<UnitOptionsState> = (state = defaultState, action: fromActions.UnitOptionsActions) => {
+const unitOptionsReducer: Reducer<UnitOptionsState> = (
+  state = defaultState,
+  action: fromActions.UnitOptionsActions
+) => {
   switch (action.type) {
     case fromActions.REQUEST_UNIT_OPTIONS:
       return {
@@ -32,7 +35,6 @@ const unitOptionsReducer: Reducer<UnitOptionsState> = (state = defaultState, act
         unitOptions: action.payload
       };
     case fromActions.RECEIVE_UNIT_OPTIONS_FAILURE:
-      console.log(action.payload);
       return {
         ...state,
         isFetching: false,

--- a/frontend/bidsoup/src/app/reducers/userAccountReducer.ts
+++ b/frontend/bidsoup/src/app/reducers/userAccountReducer.ts
@@ -17,7 +17,10 @@ const defaultState: UserAccountState = {
   fetchError: false
 };
 
-const userAccountReducer: Reducer<UserAccountState> = (state = defaultState, action: fromActions.UserAccountActions) => {
+const userAccountReducer: Reducer<UserAccountState> = (
+  state = defaultState,
+  action: fromActions.UserAccountActions
+) => {
   switch (action.type) {
     case fromActions.REQUEST_USER_ACCOUNT:
       return {

--- a/frontend/bidsoup/src/app/taskItem/actions/bidTasksActions.ts
+++ b/frontend/bidsoup/src/app/taskItem/actions/bidTasksActions.ts
@@ -83,7 +83,7 @@ export const updateBidTask = (task: BidTask):
   ThunkAction<Promise<any>, AppState, never, Actions> => (
   async dispatch => (
     Http2.Defaults.put(task.url, task, bidTask)
-      .map<Actions>(task => dispatch(Actions.receiveBidTask(task)))
+      .map<Actions>(taskResp => dispatch(Actions.receiveBidTask(taskResp)))
       .getOrElseL(err => dispatch(Actions.receiveBidTaskFailure(err, task.url))).run()
   )
 );

--- a/frontend/bidsoup/src/app/taskItem/actions/unitTypeActions.ts
+++ b/frontend/bidsoup/src/app/taskItem/actions/unitTypeActions.ts
@@ -78,7 +78,7 @@ export const updateUnitType = (unit: ExpandedUnit):
   ThunkAction<Promise<any>, AppState, never, Actions> => (
   async dispatch => (
     Http2.Defaults.put(unit.url, unit, unitType)
-      .map<Actions>(unit => dispatch(Actions.receiveUnitType(unit)))
+      .map<Actions>(unitResp => dispatch(Actions.receiveUnitType(unitResp)))
       .getOrElseL(err => dispatch(Actions.receiveUnitTypeFailure(err, unit.url))).run()
   )
 );

--- a/frontend/bidsoup/src/app/taskItem/components/EditBidItemForm.tsx
+++ b/frontend/bidsoup/src/app/taskItem/components/EditBidItemForm.tsx
@@ -216,7 +216,14 @@ class EditBidItemForm extends React.Component<Props, State> {
   categoryDropdown = () => {
     const categoryOptions = this.props.categories.map(c => ({id: c.url, value: c.name}));
     const selectedCategory = categoryOptions.find(c => c.id === this.state.values.category)!;
-    return <Dropdown id="category" options={categoryOptions} selected={selectedCategory} onSelect={this.selectCategory}/>;
+    return (
+      <Dropdown
+        id="category"
+        options={categoryOptions}
+        selected={selectedCategory}
+        onSelect={this.selectCategory}
+      />
+    );
   }
 
   unitDropdown = () => {

--- a/frontend/bidsoup/src/app/taskItem/components/EditTaskForm.tsx
+++ b/frontend/bidsoup/src/app/taskItem/components/EditTaskForm.tsx
@@ -117,11 +117,13 @@ export default class EditTaskForm extends React.Component<Props, State> {
               onBlur={this.validateAndSubmit}
             />
           </span>
-          <ActionHeader options={[
-            { icon: 'clear', action: this.props.unselectTask },
-            { icon: 'delete', action: () => this.props.showModal('deleteTaskModal'), danger: true },
-            { icon: 'link' },
-          ]}/>
+          <ActionHeader
+            options={[
+              { icon: 'clear', action: this.props.unselectTask },
+              { icon: 'delete', action: () => this.props.showModal('deleteTaskModal'), danger: true },
+              { icon: 'link' },
+            ]}
+          />
         </TaskTitleContainer>
         <TaskDescriptionContainer>
           <Icon className="material-icons">notes</Icon>

--- a/frontend/bidsoup/src/app/taskItem/containers/EditTaskFormContainer.ts
+++ b/frontend/bidsoup/src/app/taskItem/containers/EditTaskFormContainer.ts
@@ -20,7 +20,9 @@ const mapStateToProps = (state: AppState): StateProps => ({
   task: state.bidData.tasks.selectedTask!
 });
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<AppState, never, Actions | uiActions | tasksActions>): DispatchProps => ({
+const mapDispatchToProps = (
+  dispatch: ThunkDispatch<AppState, never, Actions | uiActions | tasksActions>
+): DispatchProps => ({
   updateTask: (t: BidTask) => dispatch(updateBidTask(t)),
   showModal: (modalId: string) => dispatch(uiActions.showModal(modalId)),
   unselectTask: () => dispatch(tasksActions.clearSelectedBidTask())

--- a/frontend/bidsoup/src/app/utils/conversions.ts
+++ b/frontend/bidsoup/src/app/utils/conversions.ts
@@ -27,8 +27,12 @@ const zeroOrPercent = (value: string | null) => (
   isDefined(value) ? (Number(value) / 100) : 0
 );
 
-export const normalizeItem =
-  (item: BidItem, units: UnitDict, {markupPercent, taxable, color}: Category, tax: Bid['taxPercent']): StandardizedItem => {
+export const normalizeItem = (
+  item: BidItem,
+  units: UnitDict,
+  {markupPercent, taxable, color}: Category,
+  tax: Bid['taxPercent']
+): StandardizedItem => {
     let price = isDefined(item.unitType)
     ? Number(units[item.unitType].unitPrice)
     : Number(item.price);


### PR DESCRIPTION
Still have these, but not sure if we want to fix:
```
/usr/app/src/app/actions/unitOptionsActions.ts
(31,23): Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.
(37,71): object access via string literals is disallowed
(37,79): object access via string literals is disallowed
(37,87): object access via string literals is disallowed

/usr/app/src/app/dashboard/actions/bidActions.ts
(127,67): Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.
(140,23): Calls to 'console.log' are not allowed.

/usr/app/src/app/dashboard/actions/unitActions.ts
(19,23): Calls to 'console.log' are not allowed.

/usr/app/src/app/dashboard/components/BidOverview.tsx
(103,29): Calls to 'console.log' are not allowed.

/usr/app/src/app/taskItem/actions/bidItemsActions.ts
(62,23): Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.

/usr/app/src/app/taskItem/actions/bidTasksActions.ts
(77,25): Calls to 'console.log' are not allowed.
(83,23): Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.
(103,21): Calls to 'console.log' are not allowed.

/usr/app/src/app/taskItem/actions/unitTypeActions.ts
(58,55): Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.
(78,23): Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.
(87,23): Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.
```