### PR TITLE
Remove 'bids' namespace from urls

### DIFF
--- a/backend/bidsoup/bids/mailer.py
+++ b/backend/bidsoup/bids/mailer.py
@@ -19,5 +19,5 @@ def send_magic_link(magic_link, request):
         (magic_link.user.email,))
 
 def magic_link_to_context(magic, request):
-    url = request.build_absolute_uri(reverse('bids:confirm', args=(magic.link,)))
+    url = request.build_absolute_uri(reverse('confirm', args=(magic.link,)))
     return Context({'username': magic.user.username, 'link_url': url})

--- a/backend/bidsoup/bids/urls.py
+++ b/backend/bidsoup/bids/urls.py
@@ -25,7 +25,6 @@ bids_router.register(r'bidtasks', views.BidTaskViewSet, base_name='bid-bidtask')
 category_router = routers.NestedSimpleRouter(router, r'categories', lookup='category')
 category_router.register(r'biditems', views.BidItemViewSet, base_name='category-biditem')
 
-app_name = 'bids'
 urlpatterns = [
     path('login/', views.SessionLoginView.as_view()),
     path('csrftoken/', views.get_csrf_token),

--- a/bidsoup_nginx.conf
+++ b/bidsoup_nginx.conf
@@ -22,8 +22,8 @@ http {
         # max upload size
         client_max_body_size 75M;
 
-        # Backend API
-        location /api {
+        # Backend API and admin
+        location ~ ^/(api|admin) {
             include uwsgi_params;
             uwsgi_pass django;
             proxy_set_header Host $host;

--- a/bidsoup_nginx_dev.conf
+++ b/bidsoup_nginx_dev.conf
@@ -22,8 +22,8 @@ http {
         # max upload size
         client_max_body_size 75M;
 
-        # Backend API
-        location /api {
+        # Backend API and admin
+        location ~ ^/(api|admin) {
             proxy_pass http://django;
             proxy_set_header Host $host;
         }


### PR DESCRIPTION
Since there is only one app, removed the bids namespace to simply
configuration and correct an issue where DRF could not reverse. Also
updated the nginx configs so admin is reachable.