### PR TITLE
Ensure index is tried before 404

### DIFF
--- a/bidsoup_nginx.conf
+++ b/bidsoup_nginx.conf
@@ -37,6 +37,7 @@ http {
         # Static
         location / {
             alias /code/bidsoup/bids/static/;
+            try_files $uri /index.html =404;
         }
 
     }


### PR DESCRIPTION
Production was returning 404s because the path has to match exactly. When testing prod locally, I never noticed this because the service worker would intercept these requests. However, since we don't have a cert yet and are using plain http, service workers are disabled so the bug is exposed. We should always try `index.html` before returning 404 since the frontend is handing so much of the routing.