### PR TITLE
Send to discord before email

### DIFF
--- a/backend/bidsoup/bids/magic.py
+++ b/backend/bidsoup/bids/magic.py
@@ -2,6 +2,11 @@ from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.template import Template, Context
 from django.urls import reverse
+from textwrap import dedent
+import os
+import requests
+
+DISCORD_HOOK_URL = os.environ.get('DISCORD_HOOK_URL')
 
 plain_text_template = Template(
     '''
@@ -10,13 +15,29 @@ plain_text_template = Template(
     '''
 )
 
-def send_magic_link(magic_link, request):
+discord_template = Template(
+    '''
+    Account created for user: `{{username}}`.
+    **Send email:** {{link_url}}?send
+    **Delete:** {{link_url}}?delete
+    '''
+)
+
+def send_magic_link_email(magic_link, request):
     context = magic_link_to_context(magic_link, request)
-    text_content = plain_text_template.render(context)
+    text_content = dedent(plain_text_template.render(context))
     send_mail('Welcome.',
         text_content,
         'donotreply@bidsoup.com',
         (magic_link.user.email,))
+
+def send_magic_link_discord(magic_link, request):
+    context = magic_link_to_context(magic_link, request)
+    content = dedent(discord_template.render(context))
+    if DISCORD_HOOK_URL:
+        requests.post(DISCORD_HOOK_URL, json={'content': content})
+    else:
+        print(content)
 
 def magic_link_to_context(magic, request):
     url = request.build_absolute_uri(reverse('confirm', args=(magic.link,)))

--- a/backend/bidsoup/bids/serializers.py
+++ b/backend/bidsoup/bids/serializers.py
@@ -112,5 +112,5 @@ class LoginSerializer(serializers.Serializer):
 
 class SignupSerializer(serializers.Serializer):
     username = serializers.CharField(max_length=150)
-    password = serializers.CharField(max_length=128)
+    password = serializers.CharField(max_length=128, write_only=True)
     email = serializers.EmailField()

--- a/backend/bidsoup/bids/users.py
+++ b/backend/bidsoup/bids/users.py
@@ -8,3 +8,8 @@ def confirm_user(magic_link):
         user.is_active = True
         user.save()
         ml.delete()
+
+def delete_user(magic_link):
+    ml = MagicLink.objects.filter(link=magic_link).get()
+    ml.user.delete()
+    ml.delete()

--- a/backend/bidsoup/bidsoup/settings.py
+++ b/backend/bidsoup/bidsoup/settings.py
@@ -145,7 +145,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
+SENDGRID_ECHO_TO_STDOUT = DEBUG
+EMAIL_BACKEND = 'sendgrid_backend.SendgridBackend'
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,8 +2,10 @@ uWSGI==2.0.15
 Django==2.0.1
 django-extensions==2.1.3
 django-rest-framework-rules==1.0.0
+django-sendgrid-v5==0.8.0
 djangorestframework==3.7.7
 djangorestframework-camel-case==0.2.0
 djangorestframework-recursive==0.1.2
 drf-nested-routers==0.90.2
 psycopg2==2.7.3.2
+requests==2.22.0

--- a/frontend/bidsoup/src/app/login/actions/signupActions.ts
+++ b/frontend/bidsoup/src/app/login/actions/signupActions.ts
@@ -39,7 +39,7 @@ export const signup = (user: string, password: string, email: string):
       body: JSON.stringify({ 'username': user, 'password': password, 'email': email })
     });
 
-    if (response.status === 200) {
+    if (response.status === 201) {
       dispatch(Actions.signupSuccess());
       history.push('/check-email');
     } else {

--- a/frontend/bidsoup/src/app/login/components/EmailSent.tsx
+++ b/frontend/bidsoup/src/app/login/components/EmailSent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
 
 export const EmailSent = () => (
-  <p>Email Sent. Please check your inbox.</p>
+  <p>You will be receiving an email shortly. Please check your inbox to confirm your account.</p>
 );


### PR DESCRIPTION
Integrate with sendgrid and send a link to discord to act as gate before
sending email.

Depends on corresponding changes in bidsoup-infra PR#2