### PR TITLE
Fetch some items in parallel

### DIFF
--- a/frontend/bidsoup/src/app/dashboard/components/BidOverview.tsx
+++ b/frontend/bidsoup/src/app/dashboard/components/BidOverview.tsx
@@ -18,7 +18,7 @@ interface Props {
   selectedBidId: number;
   units: Unit[];
   createUnitType: (u: Partial<Unit>) => Promise<void>;
-  loadPage: () => Promise<void>;
+  loadPage: () => Promise<void[]>;
   deleteBid: (bidUrl: string) => Promise<Actions>;
   showModal: (modalId: string) => void;
   hideModal: (modalId: string) => void;

--- a/frontend/bidsoup/src/app/dashboard/containers/BidOverviewContainer.ts
+++ b/frontend/bidsoup/src/app/dashboard/containers/BidOverviewContainer.ts
@@ -29,7 +29,7 @@ interface StateProps {
 
 interface DispatchProps {
   createUnitType: (u: Partial<Unit>) => Promise<void>;
-  loadPage: () => Promise<void>;
+  loadPage: () => Promise<void[]>;
   deleteBid: (bidUrl: string) => Promise<Actions>;
   showModal: (modalId: string) => void;
   hideModal: (modalId: string) => void;
@@ -85,12 +85,13 @@ const mapDispatchToProps = (
   ownProps: RouteComponentProps<{bid: string}>
 ): DispatchProps => ({
   createUnitType: (unit: Partial<Unit>) => dispatch(createUnitType(unit)),
-  loadPage: () => (
-    dispatch(fetchBidListByAccount())
-      .then(() => dispatch(fetchCustomerList()))
-      .then(() => dispatch(setAndFetchBidByKey(Number(ownProps.match.params.bid))))
-      .then(() => dispatch(fetchUnitOptions()))
-  ),
+  loadPage: () =>
+    Promise.all([
+      dispatch(fetchBidListByAccount())
+        .then(() => dispatch(setAndFetchBidByKey(Number(ownProps.match.params.bid)))),
+      dispatch(fetchCustomerList()),
+      dispatch(fetchUnitOptions())
+    ]),
   deleteBid: (bidUrl: string) => dispatch(deleteBid(bidUrl)).then(() => dispatch(Actions.clearSelectedBid())),
   showModal: (modalId: string) => dispatch(uiActions.showModal(modalId)),
   hideModal: (modalId: string) => dispatch(uiActions.hideModal(modalId)),

--- a/frontend/bidsoup/src/app/taskItem/actions/bidComponentsActions.js
+++ b/frontend/bidsoup/src/app/taskItem/actions/bidComponentsActions.js
@@ -7,7 +7,8 @@ const fetchBidComponents = () => {
   return (dispatch, getState) => {
     return Promise.all([
       dispatch(tasksActions.fetchBidTasks()),
-      dispatch(unitActions.fetchUnitTypes()).then(() => dispatch(fetchBidItems())),
+      dispatch(unitActions.fetchUnitTypes()),
+      dispatch(fetchBidItems()),
       dispatch(categoriesActions.fetchBidCategories()),
     ]);
   }


### PR DESCRIPTION
Some of the bid data and account data doesn't have to fetch in serial. Move to `Promise.all` for faster loading.