### PR TITLE
Generate account for new users

### DIFF
--- a/backend/bidsoup/bids/users.py
+++ b/backend/bidsoup/bids/users.py
@@ -1,13 +1,34 @@
-from .models import MagicLink
-from django.db import transaction
+from .models import Account, MagicLink
+import re
+from django.db import transaction, IntegrityError
 
 def confirm_user(magic_link):
     ml = MagicLink.objects.filter(link=magic_link).get()
     user = ml.user
     with transaction.atomic():
+        # Create a test account until we have a better way to associate the user
+        name = re.search(r'\w+', user.email)[0].lower()
+
+        # Check for similar slugs
+        similar = list(Account.objects.filter(slug__startswith=name))
+        similar = [a.slug for a in similar]
+        if name in similar:
+            i = 1
+            test = f'{name}-{i}'
+            while test in similar:
+                i = i + 1
+                test = f'{name}-{i}'
+
+            name = test
+
+        account = Account(name=name, slug=name)
+        account.save()
+
+        user.accounts.add(account)
         user.is_active = True
         user.save()
         ml.delete()
+
 
 def delete_user(magic_link):
     ml = MagicLink.objects.filter(link=magic_link).get()

--- a/backend/bidsoup/bids/views.py
+++ b/backend/bidsoup/bids/views.py
@@ -147,8 +147,6 @@ def update_order(task, relative_order):
         update_order(task.get('children')[o], o)
 
 
-
-
 class CategoryViewSet(PermissionRequiredMixin, TrapDjangoValidationErrorMixin, viewsets.ModelViewSet):
     permission_required = 'bids.view_categories'
     object_permission_required = 'bids.owns_category'

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
 
   backend:
     volumes:
-      - ./backend/bidsoup:/code/bidsoup/
+      - ./backend/bidsoup:/code/bidsoup
     command: /bin/bash /code/start-dev.sh
     environment:
       - 'DEBUG=True'
@@ -20,15 +20,13 @@ services:
 
   frontend:
     volumes:
-      - ./frontend/bidsoup/src:/usr/app/src/
-      - ./frontend/bidsoup/public:/usr/app/public/
+      - ./frontend/bidsoup/src:/usr/app/src
+      - ./frontend/bidsoup/public:/usr/app/public
       - ./frontend/bidsoup/tslint.json:/usr/app/tslint.json
       - ./frontend/bidsoup/tsconfig.json:/usr/app/tsconfig.json
       - ./frontend/bidsoup/.env.development:/usr/app/.env.development
     ports:
       - 3000:3000
-    environment:
-      - CHOKIDAR_USEPOLLING=true
 
   db:
     ports:

--- a/frontend/bidsoup/src/app/dashboard/components/BidSelector.tsx
+++ b/frontend/bidsoup/src/app/dashboard/components/BidSelector.tsx
@@ -59,15 +59,14 @@ const bidForm = ({showModal, hideModal}: Props) => (
 );
 
 const BidSelector = (props: Props) => {
-  const { account, bids } = props;
-
+  const {account} = props;
   React.useEffect(
     () => {
-      if (isEmpty(bids) && isDefined(account)) {
+      if (isEmpty(props.bids) && isDefined(account)) {
         props.loadBids();
       }
     },
-    [account, bids]
+    [props.account]
   );
 
   let cards = props.bids.length === 0


### PR DESCRIPTION
Temporary fix to auto-create an account for new users when they sign up. This is in place of a UI workflow where they would then optionally join another account (via invitation or code) or be creating a new account where they would become owners.